### PR TITLE
Add clip-path 

### DIFF
--- a/client/twitch-giphy.css
+++ b/client/twitch-giphy.css
@@ -6,16 +6,19 @@
   visibility: hidden;
 
   padding: 1em;
-  grid-template-rows: 2.5em 1fr;
+  grid-template-rows: 1fr 3em;  
+  filter: drop-shadow(-1px 6px 3px rgba(50, 50, 0, 0.5));
 }
 
-.twitch-giphy__gif {
+.twitch-giphy__gif {  
   width: 100%;
   height: 100%;
+  clip-path: polygon(0% 0%, 100% 0%, 100% 90%, 41% 90%, 21% 100%, 26% 90%, 0 90%);
 }
 
 .twitch-giphy .twitch-giphy__sender {
   font-size: 1.5em;
+  padding: 10px 30px;
 }
 
 .twitch-giphy .twitch-giphy__sender .sender__username {

--- a/client/twitch.giphy.js
+++ b/client/twitch.giphy.js
@@ -33,8 +33,8 @@
     this.iframe.frameBorder = 0;
     this.iframe.allowFullScreen = true;
 
-    this.target.appendChild(this.sender);
     this.target.appendChild(this.iframe);
+    this.target.appendChild(this.sender);
 
     this.socket = io.connect(location.origin);
     this.socket.on('giphy', this.push.bind(this));
@@ -84,7 +84,8 @@
     if (this.iframe.src !== data.gif) {
       console.info(`Loading gif ${data.gif}`);
       this.target.style.visibility = 'visible';
-      this.target.style.backgroundColor = data.color;
+      this.iframe.style.backgroundColor = data.color;
+      this.sender.style.backgroundColor = data.color;
 
       this.iframe.src = data.gif;
       this.iframe.onload = () => {
@@ -107,7 +108,8 @@
    */
   TwitchGiphy.prototype.hide = function() {
     this.target.style.visibility = 'hidden';
-    this.target.style.removeProperty('backgroundColor');
+    this.iframe.style.removeProperty('backgroundColor');
+    this.sender.style.removeProperty('backgroundColor');
   };
 
   $.TwitchGiphy = TwitchGiphy;


### PR DESCRIPTION
fixes #4 

@fernanDOTdo neste eu usei o clip-path do css e acredito se uma boa solução pois o return do giphy nao vem patronizado assim evita cortar muito a o gif. 

Deixe me saber o que voce acha!

# Screenshot

![Screenshot_2020-03-07_23-41-46](https://user-images.githubusercontent.com/34720135/76155926-cce1c180-60d1-11ea-952b-2d8517c603e8.png)
![Screenshot_2020-03-07_23-40-24](https://user-images.githubusercontent.com/34720135/76155928-cfdcb200-60d1-11ea-9607-8ec0eab511ef.png)
