### PR TITLE
fix: set about:blank in the iframe.src when hide

### DIFF
--- a/client/twitch.giphy.js
+++ b/client/twitch.giphy.js
@@ -106,6 +106,7 @@
    *  Remove exibição do gif
    */
   TwitchGiphy.prototype.hide = function() {
+    this.iframe.src = 'about:blank';
     this.target.style.visibility = 'hidden';
     this.target.style.removeProperty('backgroundColor');
   };


### PR DESCRIPTION
Aqui adicionei o about:blank no iframe quando ele esta no hide para evitar de mostrar o gif anterior quando a nova gif esta visivel.